### PR TITLE
Spelling fixes for Zork I (German)

### DIFF
--- a/dungeon.zil
+++ b/dungeon.zil
@@ -988,7 +988,7 @@ southwest, is marked %>To Stone Barrow%<."
 	(FLAGS READBIT TAKEBIT BURNBIT DASBIT)
 	(SIZE 2)
 	(TEXT
-" !!!!FROBOZ ZAUBERBOOTFABRIK!!!!|
+" !!!!FROBOZZ ZAUBERBOOTFABRIK!!!!|
 |
 Tag, Seeman!|
 |


### PR DESCRIPTION
These are the spelling fixes for Zork I (German) from The ZIL Files. The usual caveats apply: I'm not a native German speaker, so please check that the fixes are correct.